### PR TITLE
Fix js syntax that was causing cap staging deploy error

### DIFF
--- a/app/assets/javascripts/spree/frontend/spree_subscribe.js
+++ b/app/assets/javascripts/spree/frontend/spree_subscribe.js
@@ -1,4 +1,3 @@
-###
 (function($) {
   $(document).ready(function(){
     if ($("#product-variants").length) {
@@ -53,4 +52,3 @@
   }
 
 })(jQuery);
-###


### PR DESCRIPTION
This seems to be causing an error during cap staging deploy
